### PR TITLE
Improved backend check logic

### DIFF
--- a/src/store/app/actions.js
+++ b/src/store/app/actions.js
@@ -34,7 +34,7 @@ export async function node ({ commit, state }) {
         10000,
       )
       const rpcurl = state.settings.node[i].protocol + '://' + state.settings.node[i].address + ':' + state.settings.node[i].port + state.settings.node[i].path
-      const Init = { method:'POST',body: '{"action":"account_info"}'}
+      const Init = { method:'POST',body: '{"action":"block_count"}'}
       Init.signal = controller.signal
       Init.headers = {}
       if ('headers' in state.settings.node[i]) {
@@ -48,12 +48,17 @@ export async function node ({ commit, state }) {
         const res = await fetch(rpcurl,Init)
         clearTimeout(timeout)
         if (res.ok) {
-          console.log("Backend OK: " + rpcurl)
-          newnode = {
-            ...newnode,
-            ...state.settings.node[i]
+          let data = await res.json()
+          if (data.count) {
+            console.log("Backend OK: " + rpcurl)
+            newnode = {
+              ...newnode,
+              ...state.settings.node[i]
+            }
+            break
+          } else {
+            console.log(res)
           }
-          break
         } else {
           console.log(res)
         }


### PR DESCRIPTION
Instead of checking backend health with "account_info" I think it's better to check "block_count" which is a basic function that will also be needed if doing #24. This logic enables to detect if the rpc node is down when behind a proxy server because the proxy server (depending on implementation) may respond with a json containing "error" and that is indistinguishable from what account_info would respond with for an invalid account (error=Account not found). I didn't want to introduce yet another RPC action but that's the reason. It's better than just checking "res.ok" because that may be "true" when node is down if the rpc proxy is built that way.

If merging this, you may need to check allowed commands for your nano docker container and allow block_count. https://github.com/linuxserver/docker-nano/blob/master/root/defaults/rpc-proxy.json