### PR TITLE
Fix console error "split of null"

### DIFF
--- a/src/components/BlockState.vue
+++ b/src/components/BlockState.vue
@@ -119,7 +119,7 @@ export default {
     if(this.static) {
       this.getDetails(this.$route.params.hash)
     }
-    if (this.$route.name !== 'Block' && this.$store.state.app.node.address.split('.').slice(-2)[0] == 'linuxserver') {
+    if (this.$route.name !== 'Block' && this.$store.state.app.node.address !== undefined && this.$store.state.app.node.address !== null && this.$store.state.app.node.address.split('.').slice(-2)[0] == 'linuxserver') {
       this.net = 'lsio'
     } else {
       this.net = 'live'


### PR DESCRIPTION
If the server url is not provided (changeAddress=false) I get either console error "cant find split of undefined" or "cant find split of null" depending on which landing page you load. Maybe this logic is not the best but it solves the problem.